### PR TITLE
Rewrite main.js to load map and form

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,8 @@
     <title>Vite App</title>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="map"></div>
+    <div id="marker-form"></div>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,24 +1,9 @@
 import './style.css'
-import javascriptLogo from './javascript.svg'
-import viteLogo from '/vite.svg'
-import { setupCounter } from '../counter.js'
+import { createMap } from './map.js'
+import { createMarkerForm } from './markerform.js'
 
-document.querySelector('#app').innerHTML = `
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="${viteLogo}" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" target="_blank">
-      <img src="${javascriptLogo}" class="logo vanilla" alt="JavaScript logo" />
-    </a>
-    <h1>Hello Vite!</h1>
-    <div class="card">
-      <button id="counter" type="button"></button>
-    </div>
-    <p class="read-the-docs">
-      Click on the Vite logo to learn more
-    </p>
-  </div>
-`
-
-setupCounter(document.querySelector('#counter'))
+// Initialize application once the DOM is fully loaded
+document.addEventListener('DOMContentLoaded', () => {
+  createMap()
+  createMarkerForm()
+})

--- a/src/map.js
+++ b/src/map.js
@@ -1,0 +1,6 @@
+export function createMap() {
+  const mapContainer = document.getElementById('map')
+  if (!mapContainer) return
+  // Placeholder implementation. Replace with actual map setup.
+  mapContainer.textContent = 'Map goes here'
+}

--- a/src/markerform.js
+++ b/src/markerform.js
@@ -1,0 +1,11 @@
+export function createMarkerForm() {
+  const formContainer = document.getElementById('marker-form')
+  if (!formContainer) return
+  // Placeholder form. Replace with actual form elements.
+  const form = document.createElement('form')
+  const input = document.createElement('input')
+  input.type = 'text'
+  input.placeholder = 'Marker name'
+  form.appendChild(input)
+  formContainer.appendChild(form)
+}


### PR DESCRIPTION
## Summary
- strip the Vite demo code from `main.js`
- add DOM-ready initialization of `createMap` and `createMarkerForm`
- create placeholder implementations for `createMap` and `createMarkerForm`
- update `index.html` with `map` and `marker-form` containers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846e02edfc0832db8b519fe219348d6