### PR TITLE
Add createMarkerForm placeholder

### DIFF
--- a/src/markerform.js
+++ b/src/markerform.js
@@ -1,11 +1,5 @@
 export function createMarkerForm() {
   const formContainer = document.getElementById('marker-form')
   if (!formContainer) return
-  // Placeholder form. Replace with actual form elements.
-  const form = document.createElement('form')
-  const input = document.createElement('input')
-  input.type = 'text'
-  input.placeholder = 'Marker name'
-  form.appendChild(input)
-  formContainer.appendChild(form)
+  formContainer.innerText = 'Marker form goes here'
 }


### PR DESCRIPTION
## Summary
- implement `createMarkerForm` as a simple placeholder
- it selects `#marker-form` and sets the text to `"Marker form goes here"`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846e1d0a084832d854e783b61884f78