### PR TITLE
Add CSS dimensions for map

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -42,6 +42,11 @@ h1 {
   text-align: center;
 }
 
+#map {
+  min-height: 400px;
+  width: 100%;
+}
+
 .logo {
   height: 6em;
   padding: 1.5em;


### PR DESCRIPTION
## Summary
- ensure map container is visible during development by setting minimum height and width

## Testing
- `npm run build` *(fails: Rollup failed to resolve import `@supabase/supabase-js`)*

------
https://chatgpt.com/codex/tasks/task_e_6846e2cccb34832d9188a91a1552c0b2