### PR TITLE
Display MapLibre map

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -1,6 +1,19 @@
+import maplibregl from 'maplibre-gl'
+import 'maplibre-gl/dist/maplibre-gl.css'
+
 export function createMap() {
   const mapContainer = document.getElementById('map')
   if (!mapContainer) return
-  // Placeholder implementation. Replace with actual map setup.
-  mapContainer.innerText = 'Map will go here'
+
+  // Remove any placeholder text
+  mapContainer.textContent = ''
+
+  const map = new maplibregl.Map({
+    container: mapContainer,
+    style: 'https://demotiles.maplibre.org/style.json',
+    center: [-74.006, 40.7128],
+    zoom: 11
+  })
+
+  return map
 }


### PR DESCRIPTION
## Summary
- initialize MapLibre in `createMap`
- remove placeholder text from map container
- add MapLibre stylesheet import

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684872ac71f4832d85b42722700df172