### PR TITLE
Display markers on MapLibre map

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,18 +5,21 @@ import { supabase } from './supabase.js'
 
 // Initialize application once the DOM is fully loaded
 document.addEventListener('DOMContentLoaded', async () => {
-  createMap()
-  createMarkerForm()
+  let markers = []
 
-  // Fetch all markers from Supabase and log them
+  // Fetch all markers from Supabase
   try {
     const { data, error } = await supabase.from('markers').select('*')
     if (error) {
       console.error('Error fetching markers:', error)
     } else {
+      markers = data
       console.log('Fetched markers:', data)
     }
   } catch (err) {
     console.error('Unexpected error fetching markers:', err)
   }
+
+  createMap('map', markers)
+  createMarkerForm()
 })

--- a/src/map.js
+++ b/src/map.js
@@ -1,8 +1,8 @@
 import maplibregl from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
-export function createMap() {
-  const mapContainer = document.getElementById('map')
+export function createMap(containerId = 'map', markers = []) {
+  const mapContainer = document.getElementById(containerId)
   if (!mapContainer) return
 
   // Remove any placeholder text
@@ -13,6 +13,17 @@ export function createMap() {
     style: 'https://demotiles.maplibre.org/style.json',
     center: [-74.006, 40.7128],
     zoom: 11
+  })
+
+  // Add markers to the map
+  markers.forEach(({ lat, lng, type, notes }) => {
+    const popup = new maplibregl.Popup({ offset: 25 }).setHTML(
+      `<strong>${type}</strong><p>${notes}</p>`
+    )
+    new maplibregl.Marker()
+      .setLngLat([lng, lat])
+      .setPopup(popup)
+      .addTo(map)
   })
 
   return map


### PR DESCRIPTION
## Summary
- extend `createMap` to accept a container id and marker array
- loop through markers and add them with popups
- fetch markers from Supabase before initializing the map

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848735c936c832d93522d2f64f25a2f