### PR TITLE
Update colors and default map style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cityhive2",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cityhive2",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.48.2",
         "eslint": "^9.29.0",

--- a/src/auth.js
+++ b/src/auth.js
@@ -43,11 +43,11 @@ function createAuthModal() {
                 </div>
                 <div class="form-field">
                     <label for="email">Email</label>
-                    <input type="email" id="email" name="email" required placeholder="your@email.com" autocomplete="email" style="opacity: 1; visibility: visible; display: block; background: #ffffff; color: #0f172a;" />
+                    <input type="email" id="email" name="email" required placeholder="your@email.com" autocomplete="email" style="opacity: 1; visibility: visible; display: block; background: var(--white); color: var(--text-primary);" />
                 </div>
                 <div class="form-field">
                     <label for="password">Password</label>
-                    <input type="password" id="password" name="password" required placeholder="••••••••" autocomplete="current-password" style="opacity: 1; visibility: visible; display: block; background: #ffffff; color: #0f172a;" />
+                    <input type="password" id="password" name="password" required placeholder="••••••••" autocomplete="current-password" style="opacity: 1; visibility: visible; display: block; background: var(--white); color: var(--text-primary);" />
                 </div>
                 <button type="submit" id="auth-submit-btn" class="auth-submit-btn">Sign In</button>
             </form>
@@ -218,8 +218,8 @@ export function showAuthModal() {
         targetInput.style.opacity = '1';
         targetInput.style.visibility = 'visible';
         targetInput.style.display = 'block';
-        targetInput.style.background = '#ffffff';
-        targetInput.style.color = '#0f172a';
+        targetInput.style.background = 'var(--white)';
+        targetInput.style.color = 'var(--text-primary)';
       }
     }, 100);
   } else {

--- a/src/map-controls.js
+++ b/src/map-controls.js
@@ -15,7 +15,7 @@ export class MapLayerControls {
           tree: true,
         },
       },
-      basemap: 'streets', // streets, satellite, hybrid
+      basemap: 'satellite', // streets, satellite, hybrid
     };
     this.createControls();
   }
@@ -35,12 +35,12 @@ export class MapLayerControls {
           <h4>Base Map</h4>
           <div class="basemap-options">
             <label class="basemap-option">
-              <input type="radio" name="basemap" value="streets" checked>
+              <input type="radio" name="basemap" value="streets">
               <span class="option-preview streets-preview"></span>
               <span class="option-label">Streets</span>
             </label>
             <label class="basemap-option">
-              <input type="radio" name="basemap" value="satellite">
+              <input type="radio" name="basemap" value="satellite" checked>
               <span class="option-preview satellite-preview"></span>
               <span class="option-label">Satellite</span>
             </label>

--- a/src/map.js
+++ b/src/map.js
@@ -52,7 +52,7 @@ export function initMap(containerId = 'map', onMapClick) {
     }
     const map = new maplibregl.Map({
       container: mapContainer,
-      style: `https://api.maptiler.com/maps/streets-v2/style.json?key=${mapTilerKey}`,
+      style: `https://api.maptiler.com/maps/satellite/style.json?key=${mapTilerKey}`,
       center: [-73.935242, 40.73061],
       zoom: 11,
       minZoom: 9,
@@ -357,10 +357,10 @@ function openPhotoModal(photoUrl) {
 // --- UTILITY FUNCTIONS ---
 function getMarkerColor(type, status) {
   const baseColors = {
-    Hive: '#ffaa00',
-    Swarm: '#ff6600',
-    Structure: '#666666',
-    Tree: '#00aa00',
+    Hive: '#8a7f1d', // brown-300
+    Swarm: '#958b3e', // warm-sage-600
+    Structure: '#8d8764', // sage-600
+    Tree: '#7c9082', // reseda-500
   };
   const statusModifiers = {
     Active: 1.0,
@@ -369,7 +369,7 @@ function getMarkerColor(type, status) {
     Gone: 0.3,
     Removed: 0.2,
   };
-  const baseColor = baseColors[type] || '#333333';
+  const baseColor = baseColors[type] || '#433e0e';
   const modifier = statusModifiers[status] || 0.6;
   if (modifier === 1.0) return baseColor;
   const hex = baseColor.replace('#', '');

--- a/src/pages.css
+++ b/src/pages.css
@@ -430,7 +430,7 @@
 
 .science-list li {
   padding: 0.75rem 0;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--gray-200);
   position: relative;
   padding-left: 2rem;
 }
@@ -455,14 +455,14 @@
 }
 
 .usage-item {
-  background: #f0f7ed;
+  background: var(--cream-100);
   padding: 1.5rem;
   border-radius: 8px;
-  border: 1px solid #e0e7dd;
+  border: 1px solid var(--gray-200);
 }
 
 .usage-item h4 {
-  color: #2d4a22;
+  color: var(--reseda-800);
   margin-bottom: 0.75rem;
   font-family: 'Inter', sans-serif;
   font-weight: 600;
@@ -551,7 +551,7 @@
 
 .phone {
   font-weight: 600;
-  color: #d63031;
+  color: var(--error);
   margin: 0.5rem 0;
 }
 
@@ -696,14 +696,14 @@
 }
 
 .book-item {
-  background: #f9f9f9;
+  background: var(--surface-primary);
   padding: 1.5rem;
   border-radius: 8px;
-  border-left: 4px solid #ffd700;
+  border-left: 4px solid var(--accent-sage-warm);
 }
 
 .book-item h4 {
-  color: #2d4a22;
+  color: var(--reseda-800);
   margin-bottom: 0.75rem;
   font-family: 'Inter', sans-serif;
   font-weight: 600;
@@ -756,18 +756,18 @@
 
 .quick-start-card li {
   margin-bottom: 0.5rem;
-  color: #444;
+  color: var(--reseda-700);
 }
 
 .quick-start-card a {
-  color: #2d4a22;
+  color: var(--reseda-800);
   font-weight: 600;
   text-decoration: none;
-  border-bottom: 1px solid #ffd700;
+  border-bottom: 1px solid var(--accent-sage-warm);
 }
 
 .quick-start-card a:hover {
-  color: #ffd700;
+  color: var(--accent-sage-warm);
 }
 
 /* Featured Resources */

--- a/src/style.css
+++ b/src/style.css
@@ -243,7 +243,7 @@ body {
 }
 
 .cta-section h3 {
-  color: #ffd700;
+  color: var(--accent-sage-warm);
   margin-bottom: 1rem;
   font-size: 1.5rem;
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
@@ -281,7 +281,7 @@ body {
 
 .cta-button {
   display: inline-block;
-  background: #ffd700;
+  background: var(--accent-sage-warm);
   color: var(--gray-900);
   padding: 0.75rem 1.5rem;
   border-radius: 6px;
@@ -292,7 +292,7 @@ body {
 }
 
 .cta-button:hover {
-  background: #ffc800;
+  background: var(--warm-sage-600);
   transform: translateY(-2px);
   box-shadow: 0 6px 8px rgba(0, 0, 0, 0.15);
 }
@@ -1212,7 +1212,7 @@ body {
   box-shadow: var(--shadow-sm);
 }
 .btn-delete:hover {
-  background: #dc2626;
+  background: var(--brown-400);
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);
 }
@@ -1222,7 +1222,7 @@ body {
   box-shadow: var(--shadow-sm);
 }
 .btn-update-status:hover {
-  background: #0891b2;
+  background: var(--reseda-700);
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);
 }
@@ -1707,7 +1707,7 @@ body {
 }
 
 .welcome-content footer a:hover {
-  color: #ffd700;
+  color: var(--accent-sage-warm);
   text-decoration: underline;
 }
 
@@ -1782,8 +1782,8 @@ body {
     align-items: center;
     justify-content: center;
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
-    border: 2px solid #2d4a22;
-    color: #2d4a22;
+    border: 2px solid var(--reseda-800);
+    color: var(--reseda-800);
     font-weight: bold;
   }
   .got-it-button {
@@ -2362,7 +2362,7 @@ button.nav-map-layers:hover {
 }
 
 .user-name {
-  color: #ffd700;
+  color: var(--accent-sage-warm);
   font-weight: 500;
   font-family: 'Inter', sans-serif;
 }
@@ -2412,7 +2412,7 @@ button.nav-map-layers:hover {
 }
 
 .welcome-content footer a:hover {
-  color: #ffd700;
+  color: var(--accent-sage-warm);
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Summary
- switch map tiles to satellite view by default
- adjust map layer control to select satellite at start
- use earth-tone palette variables across CSS
- style inline auth form fields with palette colors
- update marker colors to match earth tones
- keep lockfile in sync

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a4902055c832dbe3366e1da10e3f5